### PR TITLE
Rebuild with vs2017 compiler.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,0 @@
-cxx_compiler:  # [win]
-  - vs2019     # [win]
-  - vs2019     # [win]
-  - vs2019     # [win]
-c_compiler:    # [win]
-  - vs2019     # [win]
-  - vs2019     # [win]
-  - vs2019     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     # - add-verbosity-to-setup-py.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [not win]
 
 requirements:


### PR DESCRIPTION
In tracking down an issue with Anaconda Distribution shortcuts, we found that builds of `pywin32` that used different compilers from the ones used to compile `python` seemed to be the cause. Removing this cbc should use the same version as what is in aggregate. If a python recipe uses another version, we can add it back.