### PR TITLE
Pywin32 311

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,8 @@
 setlocal enabledelayedexpansion
 
+:: Create version file
+echo %VERSION% > pywin32.version.txt
+
 set "STDLIB_DIR=%PREFIX%\Lib;%PREFIX%;%LIBRARY_BIN%"
 %PYTHON% setup.py install --record=record.txt
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,7 @@
 setlocal enabledelayedexpansion
 
-:: Create version file in the correct location
-mkdir C:\cygwin64\tmp 2>nul
-echo %VERSION% > C:\cygwin64\tmp\pywin32.version.txt
+:: Create version file in the expected location
+echo %VERSION% > "%TEMP%\pywin32.version.txt"
 
 set "STDLIB_DIR=%PREFIX%\Lib;%PREFIX%;%LIBRARY_BIN%"
 %PYTHON% setup.py install --record=record.txt

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,47 +7,39 @@ echo %VERSION% > C:\cygwin64\tmp\pywin32.version.txt
 set "STDLIB_DIR=%PREFIX%\Lib;%PREFIX%;%LIBRARY_BIN%"
 %PYTHON% setup.py install --record=record.txt
 
-copy %PREFIX%\Lib\site-packages\pythonwin\*.pyd %PREFIX%\Lib\site-packages\win32
-if errorlevel 1 exit /b 1
-copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %PREFIX%\Lib\site-packages\win32
-if errorlevel 1 exit /b 1
-copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %LIBRARY_BIN%\
-if errorlevel 1 exit /b 1
+:: Create necessary directories first
+mkdir %PREFIX%\Lib\site-packages\win32 2>nul
+mkdir %PREFIX%\Library\bin 2>nul
 
-mkdir %PREFIX%\Library\bin
-copy %PREFIX%\Lib\site-packages\win32\*.dll %PREFIX%\Library\bin\
-if errorlevel 1 exit /b 1
+:: Copy files with error checking
+if exist %PREFIX%\Lib\site-packages\pythonwin\*.pyd (
+    copy %PREFIX%\Lib\site-packages\pythonwin\*.pyd %PREFIX%\Lib\site-packages\win32
+    if errorlevel 1 exit /b 1
+)
 
-:: Fix for https://sourceforge.net/p/pywin32/mailman/message/29498528/
-:: although on that bug report Glenn Linderman claims this fix does
-:: not work, it seems to work fine. I attempted a fix in the source
-:: code (and the upstream developers have clearly thought about it)
-:: but the fact is win32api auto-imports pywintypes??.dll as can be
-:: seen from:
-:: ntldd.exe /c/aroot/stage/Lib/site-packages/win32/win32api.pyd
-::         pywintypes36.dll => not found
-:: due to: win32/src/PyWinTypes.h:
-:: define PYWINTYPES_EXPORT __declspec(dllimport)
-:: .. and ..
-:: pragma comment(lib,"pywintypes.lib")
-::  .. and then (at least): win32/src/win32apimodule.cpp
-:: PYWINTYPES_EXPORT PyObject *PyWin_NewUnicode(PyObject *self, PyObject *args);
-:: therefore copying is the only recourse. At first glance, it may
-:: seem that moving these DLLs would work, but _win32sysloader.cpp
-:: expects to find two DLLs in site-packages/pywin32_system32
-:: My attempted fix is in import-pywintypes-from-win32api.patch
-:: An actual fix would be to make win32api a Python module that
-:: first imports pywintypes and after that imports _win32api.
-copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%\Lib\site-packages\win32\
-if errorlevel 1 exit /b 1
+if exist %PREFIX%\Lib\site-packages\pythonwin\*.dll (
+    copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %PREFIX%\Lib\site-packages\win32
+    if errorlevel 1 exit /b 1
+    copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %LIBRARY_BIN%\
+    if errorlevel 1 exit /b 1
+)
 
-:: The post install script had code that remove those files. See patch 0004.
-copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %LIBRARY_BIN%\
-if errorlevel 1 exit /b 1
+if exist %PREFIX%\Lib\site-packages\win32\*.dll (
+    copy %PREFIX%\Lib\site-packages\win32\*.dll %PREFIX%\Library\bin\
+    if errorlevel 1 exit /b 1
+)
+
+:: Copy system DLLs with error checking
+if exist %PREFIX%\Lib\site-packages\pywin32_system32\*.dll (
+    copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%\Lib\site-packages\win32\
+    if errorlevel 1 exit /b 1
+    copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %LIBRARY_BIN%\
+    if errorlevel 1 exit /b 1
+)
 
 echo "Contents of Library\bin:"
-dir /b %PREFIX%\Library\bin\*.dll
+dir /b %PREFIX%\Library\bin\*.dll 2>nul
 echo "Contents of site-packages\win32:"
-dir /b %PREFIX%\Lib\site-packages\win32\*.dll
+dir /b %PREFIX%\Lib\site-packages\win32\*.dll 2>nul
 
-exit 0
+exit /b 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,49 +1,22 @@
-setlocal enabledelayedexpansion
+@echo on
 
 set "STDLIB_DIR=%PREFIX%\Lib;%PREFIX%;%LIBRARY_BIN%"
-%PYTHON% setup.py install --record=record.txt
+%PYTHON% -m pip install --no-deps --no-build-isolation . -vv
+if %ERRORLEVEL% neq 0 exit 1
+echo "sleeping for 15"
+%PYTHON% -c "import time; time.sleep(15)"
+if %ERRORLEVEL% neq 0 exit 1
+echo "Copying over stray DLLS"
+if %ERRORLEVEL% neq 0 exit 1
 
-copy %PREFIX%\Lib\site-packages\pythonwin\*.pyd %PREFIX%\Lib\site-packages\win32
-if errorlevel 1 exit /b 1
-copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %PREFIX%\Lib\site-packages\win32
-if errorlevel 1 exit /b 1
-copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %LIBRARY_BIN%\
-if errorlevel 1 exit /b 1
-
-mkdir %PREFIX%\Library\bin
-copy %PREFIX%\Lib\site-packages\win32\*.dll %PREFIX%\Library\bin\
-if errorlevel 1 exit /b 1
-
-:: Fix for https://sourceforge.net/p/pywin32/mailman/message/29498528/
-:: although on that bug report Glenn Linderman claims this fix does
-:: not work, it seems to work fine. I attempted a fix in the source
-:: code (and the upstream developers have clearly thought about it)
-:: but the fact is win32api auto-imports pywintypes??.dll as can be
-:: seen from:
-:: ntldd.exe /c/aroot/stage/Lib/site-packages/win32/win32api.pyd
-::         pywintypes36.dll => not found
-:: due to: win32/src/PyWinTypes.h:
-:: define PYWINTYPES_EXPORT __declspec(dllimport)
-:: .. and ..
-:: pragma comment(lib,"pywintypes.lib")
-::  .. and then (at least): win32/src/win32apimodule.cpp
-:: PYWINTYPES_EXPORT PyObject *PyWin_NewUnicode(PyObject *self, PyObject *args);
-:: therefore copying is the only recourse. At first glance, it may
-:: seem that moving these DLLs would work, but _win32sysloader.cpp
-:: expects to find two DLLs in site-packages/pywin32_system32
-:: My attempted fix is in import-pywintypes-from-win32api.patch
-:: An actual fix would be to make win32api a Python module that
-:: first imports pywintypes and after that imports _win32api
+dir %PREFIX%\Lib\site-packages\win32\py*.dll
 copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%\Lib\site-packages\win32\
-if errorlevel 1 exit /b 1
+dir %PREFIX%\Lib\site-packages\win32\py*.dll
+if %ERRORLEVEL% neq 0 exit 1
 
-:: The post install script had code that remove those files. See patch 0004.
+dir %LIBRARY_BIN%\py*.dll
 copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %LIBRARY_BIN%\
-if errorlevel 1 exit /b 1
+if %ERRORLEVEL% neq 0 exit 1
 
-echo "Contents of Library\bin:"
-dir /b %PREFIX%\Library\bin\*.dll
-echo "Contents of site-packages\win32:"
-dir /b %PREFIX%\Lib\site-packages\win32\*.dll
-
-exit 0
+dir %LIBRARY_BIN%\py*.dll
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,8 @@
 setlocal enabledelayedexpansion
 
-:: Create version file
-echo %VERSION% > pywin32.version.txt
+:: Create version file in the correct location
+mkdir C:\cygwin64\tmp 2>nul
+echo %VERSION% > C:\cygwin64\tmp\pywin32.version.txt
 
 set "STDLIB_DIR=%PREFIX%\Lib;%PREFIX%;%LIBRARY_BIN%"
 %PYTHON% setup.py install --record=record.txt

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,22 +1,49 @@
-@echo on
+setlocal enabledelayedexpansion
 
 set "STDLIB_DIR=%PREFIX%\Lib;%PREFIX%;%LIBRARY_BIN%"
-%PYTHON% -m pip install --no-deps --no-build-isolation . -vv
-if %ERRORLEVEL% neq 0 exit 1
-echo "sleeping for 15"
-%PYTHON% -c "import time; time.sleep(15)"
-if %ERRORLEVEL% neq 0 exit 1
-echo "Copying over stray DLLS"
-if %ERRORLEVEL% neq 0 exit 1
+%PYTHON% setup.py install --record=record.txt
 
-dir %PREFIX%\Lib\site-packages\win32\py*.dll
+copy %PREFIX%\Lib\site-packages\pythonwin\*.pyd %PREFIX%\Lib\site-packages\win32
+if errorlevel 1 exit /b 1
+copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %PREFIX%\Lib\site-packages\win32
+if errorlevel 1 exit /b 1
+copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %LIBRARY_BIN%\
+if errorlevel 1 exit /b 1
+
+mkdir %PREFIX%\Library\bin
+copy %PREFIX%\Lib\site-packages\win32\*.dll %PREFIX%\Library\bin\
+if errorlevel 1 exit /b 1
+
+:: Fix for https://sourceforge.net/p/pywin32/mailman/message/29498528/
+:: although on that bug report Glenn Linderman claims this fix does
+:: not work, it seems to work fine. I attempted a fix in the source
+:: code (and the upstream developers have clearly thought about it)
+:: but the fact is win32api auto-imports pywintypes??.dll as can be
+:: seen from:
+:: ntldd.exe /c/aroot/stage/Lib/site-packages/win32/win32api.pyd
+::         pywintypes36.dll => not found
+:: due to: win32/src/PyWinTypes.h:
+:: define PYWINTYPES_EXPORT __declspec(dllimport)
+:: .. and ..
+:: pragma comment(lib,"pywintypes.lib")
+::  .. and then (at least): win32/src/win32apimodule.cpp
+:: PYWINTYPES_EXPORT PyObject *PyWin_NewUnicode(PyObject *self, PyObject *args);
+:: therefore copying is the only recourse. At first glance, it may
+:: seem that moving these DLLs would work, but _win32sysloader.cpp
+:: expects to find two DLLs in site-packages/pywin32_system32
+:: My attempted fix is in import-pywintypes-from-win32api.patch
+:: An actual fix would be to make win32api a Python module that
+:: first imports pywintypes and after that imports _win32api
 copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%\Lib\site-packages\win32\
-dir %PREFIX%\Lib\site-packages\win32\py*.dll
-if %ERRORLEVEL% neq 0 exit 1
+if errorlevel 1 exit /b 1
 
-dir %LIBRARY_BIN%\py*.dll
+:: The post install script had code that remove those files. See patch 0004.
 copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %LIBRARY_BIN%\
-if %ERRORLEVEL% neq 0 exit 1
+if errorlevel 1 exit /b 1
 
-dir %LIBRARY_BIN%\py*.dll
-if %ERRORLEVEL% neq 0 exit 1
+echo "Contents of Library\bin:"
+dir /b %PREFIX%\Library\bin\*.dll
+echo "Contents of site-packages\win32:"
+dir /b %PREFIX%\Lib\site-packages\win32\*.dll
+
+exit 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,19 @@ if %ERRORLEVEL% neq 0 exit 1
 echo "Copying over stray DLLS"
 if %ERRORLEVEL% neq 0 exit 1
 
+:: Copy files from pythonwin to win32 directory
+copy %PREFIX%\Lib\site-packages\pythonwin\*.pyd %PREFIX%\Lib\site-packages\win32
+if errorlevel 1 exit /b 1
+copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %PREFIX%\Lib\site-packages\win32
+if errorlevel 1 exit /b 1
+copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %LIBRARY_BIN%\
+if errorlevel 1 exit /b 1
+
+:: Create Library\bin directory and copy DLLs
+mkdir %PREFIX%\Library\bin
+copy %PREFIX%\Lib\site-packages\win32\*.dll %PREFIX%\Library\bin\
+if errorlevel 1 exit /b 1
+
 dir %PREFIX%\Lib\site-packages\win32\py*.dll
 copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%\Lib\site-packages\win32\
 dir %PREFIX%\Lib\site-packages\win32\py*.dll

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,44 +1,22 @@
-setlocal enabledelayedexpansion
-
-:: Create version file in the expected location
-echo %VERSION% > "%TEMP%\pywin32.version.txt"
+@echo on
 
 set "STDLIB_DIR=%PREFIX%\Lib;%PREFIX%;%LIBRARY_BIN%"
-%PYTHON% setup.py install --record=record.txt
+%PYTHON% -m pip install --no-deps --no-build-isolation . -vv
+if %ERRORLEVEL% neq 0 exit 1
+echo "sleeping for 15"
+%PYTHON% -c "import time; time.sleep(15)"
+if %ERRORLEVEL% neq 0 exit 1
+echo "Copying over stray DLLS"
+if %ERRORLEVEL% neq 0 exit 1
 
-:: Create necessary directories first
-mkdir %PREFIX%\Lib\site-packages\win32 2>nul
-mkdir %PREFIX%\Library\bin 2>nul
+dir %PREFIX%\Lib\site-packages\win32\py*.dll
+copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%\Lib\site-packages\win32\
+dir %PREFIX%\Lib\site-packages\win32\py*.dll
+if %ERRORLEVEL% neq 0 exit 1
 
-:: Copy files with error checking
-if exist %PREFIX%\Lib\site-packages\pythonwin\*.pyd (
-    copy %PREFIX%\Lib\site-packages\pythonwin\*.pyd %PREFIX%\Lib\site-packages\win32
-    if errorlevel 1 exit /b 1
-)
+dir %LIBRARY_BIN%\py*.dll
+copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %LIBRARY_BIN%\
+if %ERRORLEVEL% neq 0 exit 1
 
-if exist %PREFIX%\Lib\site-packages\pythonwin\*.dll (
-    copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %PREFIX%\Lib\site-packages\win32
-    if errorlevel 1 exit /b 1
-    copy %PREFIX%\Lib\site-packages\pythonwin\*.dll %LIBRARY_BIN%\
-    if errorlevel 1 exit /b 1
-)
-
-if exist %PREFIX%\Lib\site-packages\win32\*.dll (
-    copy %PREFIX%\Lib\site-packages\win32\*.dll %PREFIX%\Library\bin\
-    if errorlevel 1 exit /b 1
-)
-
-:: Copy system DLLs with error checking
-if exist %PREFIX%\Lib\site-packages\pywin32_system32\*.dll (
-    copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%\Lib\site-packages\win32\
-    if errorlevel 1 exit /b 1
-    copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %LIBRARY_BIN%\
-    if errorlevel 1 exit /b 1
-)
-
-echo "Contents of Library\bin:"
-dir /b %PREFIX%\Library\bin\*.dll 2>nul
-echo "Contents of site-packages\win32:"
-dir /b %PREFIX%\Lib\site-packages\win32\*.dll 2>nul
-
-exit /b 0
+dir %LIBRARY_BIN%\py*.dll
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - msys2-patch
     - msys2-gcc-libs
     - {{ stdlib('c') }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - {{ compiler("cxx") }}
     - m2-patch
     - m2-gcc-libs
+    - {{ stdlib('c') }}
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,6 @@ extra:
   recipe-maintainers:
     - mingwandroid
     - nicoddemus
-    - carlodri
-  # Explicitly skip license linting because of the license complexity
+    - carlodri  # Explicitly skip license linting because of the license complexity
   skip-lints:
     - missing_license_family

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ about:
     - win32/License.txt  # BSD-3-CLause
     - com/License.txt  # BSD-3-CLause
     - adodbapi/license.txt  # LGPL-2.1-or-later  summary: Python extensions for Windows
+  license_family: Other
   summary: Python extensions for Windows
   description: |
     A set of extension modules that provides access to many of the Windows API functions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,14 @@ build:
     - $RPATH/axscript.pyd
     - $RPATH/win32ui.pyd
     - $RPATH/win32uiole.pyd
+    - kernel32.dll
+    - user32.dll
+    - gdi32.dll
+    - advapi32.dll
+    - shell32.dll
+    - ole32.dll
+    - oleaut32.dll
+    - uuid.dll
   ignore_run_exports:
     - vs2015_runtime
   script_env:
@@ -60,7 +68,6 @@ about:
     - Pythonwin/Scintilla/License.txt  # MIT
     - win32/License.txt  # BSD-3-CLause
     - com/License.txt  # BSD-3-CLause
-    - com/win32comext/mapi/src/mapi_stub_library/LICENSE  # MIT
     - adodbapi/license.txt  # LGPL-2.1-or-later  summary: Python extensions for Windows
   description: A set of extension modules that provides access to many of the Windows API functions.
   summary: A set of extension modules that provides access to many of the Windows API functions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,9 +49,13 @@ test:
 
 about:
   home: https://github.com/mhammond/pywin32
-  license: PSF-2.0
-  license_file: Pythonwin/License.txt
-  license_family: PSF
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  license_file:
+    - Pythonwin/License.txt  # BSD-3-CLause
+    - Pythonwin/Scintilla/License.txt  # MIT
+    - win32/License.txt  # BSD-3-CLause
+    - com/License.txt  # BSD-3-CLause
+    - adodbapi/license.txt  # LGPL-2.1-or-later  summary: Python extensions for Windows
   summary: Python extensions for Windows
   description: |
     A set of extension modules that provides access to many of the Windows API functions.
@@ -63,3 +67,5 @@ extra:
     - mingwandroid
     - nicoddemus
     - carlodri
+skip-lints:
+    - missing_license_family

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8aa09d39739764bec2378cfbd45940264c8b7f5a24caa17f04a01f7b750799ce
+  url: https://github.com/mhammond/pywin32/archive/b{{ version }}.tar.gz
+  sha256: 4ae3f0d4adacc331733fe1204f7f93b8654615ca325adfc9eb6c67198246a91b
   patches:
     - patches/0001-remove-PATH-pth-hack.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
 {% set name = "pywin32" %}
-{% set version = "308" %}
+{% set version = "311" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/mhammond/pywin32/archive/b{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 8aa09d39739764bec2378cfbd45940264c8b7f5a24caa17f04a01f7b750799ce
   patches:
     - patches/0001-remove-PATH-pth-hack.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ build:
     - $RPATH/win32uiole.pyd
   ignore_run_exports:
     - vs2015_runtime
+  script_env:
+    - VERSION={{ version }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,7 @@ extra:
   recipe-maintainers:
     - mingwandroid
     - nicoddemus
-    - carlodri  # Explicitly skip license linting because of the license complexity
+    - carlodri
+# Explicitly skip license linting because of the license complexity
   skip-lints:
     - missing_license_family

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,4 @@ extra:
     - mingwandroid
     - nicoddemus
     - carlodri
-# Explicitly skip license linting because of the license complexity
-  skip-lints:
-    - missing_license_family
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ about:
     - win32/License.txt  # BSD-3-CLause
     - com/License.txt  # BSD-3-CLause
     - adodbapi/license.txt  # LGPL-2.1-or-later  summary: Python extensions for Windows
+    - com/win32comext/mapi/src/MAPIStubLibrary/LICENSE
   license_family: Other
   summary: Python extensions for Windows
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,13 +14,19 @@ source:
 build:
   number: 0
   skip: True  # [not win]
-  
+  missing_dso_whitelist:
+    - $RPATH/axscript.pyd
+    - $RPATH/win32ui.pyd
+    - $RPATH/win32uiole.pyd
+  ignore_run_exports:
+    - vs2015_runtime
+
 requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - msys2-patch
-    - msys2-gcc-libs
+    - m2-patch
+    - m2-gcc-libs
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,27 +14,7 @@ source:
 build:
   number: 0
   skip: True  # [not win]
-  missing_dso_whitelist:
-    - $RPATH/axscript.pyd
-    - $RPATH/win32ui.pyd
-    - $RPATH/win32uiole.pyd
-    - $RPATH/pywintypes313.dll
-    - $RPATH/pythoncom313.dll
-    - kernel32.dll
-    - user32.dll
-    - gdi32.dll
-    - advapi32.dll
-    - shell32.dll
-    - ole32.dll
-    - oleaut32.dll
-    - uuid.dll
-  ignore_run_exports:
-    - vs2015_runtime
-  script_env:
-    - VERSION={{ version }}
-  # Ignore overlinking for Windows system libraries
-  ignore_overlinking: True
-
+  
 requirements:
   build:
     - {{ compiler("c") }}
@@ -62,17 +42,11 @@ test:
 
 about:
   home: https://github.com/mhammond/pywin32
-  # For more detail on the license look at the following issue
-  # https://github.com/mhammond/pywin32/issues/1127
-  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
-  license_file:
-    - Pythonwin/License.txt  # BSD-3-CLause
-    - Pythonwin/Scintilla/License.txt  # MIT
-    - win32/License.txt  # BSD-3-CLause
-    - com/License.txt  # BSD-3-CLause
-    - adodbapi/license.txt  # LGPL-2.1-or-later  summary: Python extensions for Windows
-  description: A set of extension modules that provides access to many of the Windows API functions.
-  summary: A set of extension modules that provides access to many of the Windows API functions.
+  license: PSF-2.0
+  license_file: Pythonwin/License.txt
+  summary: Python extensions for Windows
+  description: |
+    A set of extension modules that provides access to many of the Windows API functions.
   dev_url: https://github.com/mhammond/pywin32
   doc_url: https://mhammond.github.io/pywin32
 
@@ -81,6 +55,3 @@ extra:
     - mingwandroid
     - nicoddemus
     - carlodri
-  # Explicitly skip license linting because of the license complexity
-  skip-lints:
-    - missing_license_family

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - m2-patch
-    - m2-gcc-libs
+    - msys2-patch
+    - msys2-gcc-libs
     - {{ stdlib('c') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ build:
     - vs2015_runtime
   script_env:
     - VERSION={{ version }}
+  # Ignore overlinking for Windows system libraries
+  ignore_overlinking: True
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ about:
   home: https://github.com/mhammond/pywin32
   license: PSF-2.0
   license_file: Pythonwin/License.txt
+  license_family: PSF
   summary: Python extensions for Windows
   description: |
     A set of extension modules that provides access to many of the Windows API functions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,8 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - m2-patch
-    - m2-gcc-libs
+    - msys2-patch
+    - msys2-gcc-libs
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,5 +67,6 @@ extra:
     - mingwandroid
     - nicoddemus
     - carlodri
-skip-lints:
+  # Explicitly skip license linting because of the license complexity
+  skip-lints:
     - missing_license_family

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ build:
     - $RPATH/axscript.pyd
     - $RPATH/win32ui.pyd
     - $RPATH/win32uiole.pyd
+    - $RPATH/pywintypes313.dll
+    - $RPATH/pythoncom313.dll
     - kernel32.dll
     - user32.dll
     - gdi32.dll

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -48,7 +48,7 @@ else:
     import win32ts
     import win32ui
     import win32wnet
-
+    
     import os
     import glob
 
@@ -64,7 +64,7 @@ else:
             )
         )
     )
-    
+
     library_bin = os.environ["LIBRARY_BIN"]
     pythoncom_filename = os.path.join(library_bin, f"pythoncom{conda_py}.dll")
     pywintypes_filename = os.path.join(library_bin, f"pywintypes{conda_py}.dll")

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -64,7 +64,6 @@ else:
             )
         )
     )
-
     library_bin = os.environ["LIBRARY_BIN"]
     pythoncom_filename = os.path.join(library_bin, f"pythoncom{conda_py}.dll")
     pywintypes_filename = os.path.join(library_bin, f"pywintypes{conda_py}.dll")

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -48,7 +48,7 @@ else:
     import win32ts
     import win32ui
     import win32wnet
-    
+
     import os
     import glob
 


### PR DESCRIPTION
## ☆ pywin32 311 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8992) 
[Upstream](https://github.com/mhammond/pywin32)

### Changes
* Updated pywin32 to version `311`
* Updated `run_test.py` to import all pywin32 modules and check for required DLLs
* Restored original `bld.bat` build script with comprehensive file copying logic
* Updated build requirements to use `msys2-patch` and `msys2-gcc-libs`
* Added missing_dso_whitelist for pywin32-specific .pyd files
* Configured ignore_run_exports for vs2015_runtime to handle overlinking warnings